### PR TITLE
Mapping for GLS Bank in Germany

### DIFF
--- a/csv2ofx/mappings/gls.py
+++ b/csv2ofx/mappings/gls.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from operator import itemgetter
 
 mapping = {

--- a/csv2ofx/mappings/gls.py
+++ b/csv2ofx/mappings/gls.py
@@ -1,0 +1,13 @@
+from operator import itemgetter
+
+mapping = {
+    'has_header': True,
+    'currency': 'EUR',
+    'delimiter': ';',
+    'bank': 'GLS Bank',
+    'account': itemgetter('Kontonummer'),
+    'date': lambda r: r['Buchungstag'][3:5] + '/' + r['Buchungstag'][:2] + '/' + r['Buchungstag'][-4:], # Chop up the dotted German date format and put it in ridiculous M/D/Y order
+    'amount': lambda r: r['Betrag'].replace('.', '').replace(',', '.'), # locale.atof does not actually know how to deal with German separators, so we do it this way
+    'desc': itemgetter('Buchungstext'),
+    'payee': itemgetter('Auftraggeber/Empfänger'),
+}

--- a/csv2ofx/mappings/gls.py
+++ b/csv2ofx/mappings/gls.py
@@ -6,15 +6,15 @@ mapping = {
     'delimiter': ';',
     'bank': 'GLS Bank',
     'account': itemgetter('Kontonummer'),
-    
+
     # Chop up the dotted German date format and put it in ridiculous M/D/Y order
-    'date': lambda r: r['Buchungstag'][3:5] + '/'
-                    + r['Buchungstag'][:2] + '/'
-                    + r['Buchungstag'][-4:],
+    'date': lambda r: 
+        r['Buchungstag'][3:5] + '/' + r['Buchungstag'][:2] + '/' +
+        r['Buchungstag'][-4:],
 
     # locale.atof does not actually know how to deal with German separators.
     # So we do it the crude way
-    'amount': lambda r: r['Betrag'].replace('.', '').replace(',', '.'), 
+    'amount': lambda r: r['Betrag'].replace('.', '').replace(',', '.'),
     'desc': itemgetter('Buchungstext'),
     'payee': itemgetter('Auftraggeber/Empfänger'),
 }

--- a/csv2ofx/mappings/gls.py
+++ b/csv2ofx/mappings/gls.py
@@ -8,7 +8,7 @@ mapping = {
     'account': itemgetter('Kontonummer'),
 
     # Chop up the dotted German date format and put it in ridiculous M/D/Y order
-    'date': lambda r: 
+    'date': lambda r:
         r['Buchungstag'][3:5] + '/' + r['Buchungstag'][:2] + '/' +
         r['Buchungstag'][-4:],
 

--- a/csv2ofx/mappings/gls.py
+++ b/csv2ofx/mappings/gls.py
@@ -6,8 +6,15 @@ mapping = {
     'delimiter': ';',
     'bank': 'GLS Bank',
     'account': itemgetter('Kontonummer'),
-    'date': lambda r: r['Buchungstag'][3:5] + '/' + r['Buchungstag'][:2] + '/' + r['Buchungstag'][-4:], # Chop up the dotted German date format and put it in ridiculous M/D/Y order
-    'amount': lambda r: r['Betrag'].replace('.', '').replace(',', '.'), # locale.atof does not actually know how to deal with German separators, so we do it this way
+    
+    # Chop up the dotted German date format and put it in ridiculous M/D/Y order
+    'date': lambda r: r['Buchungstag'][3:5] + '/'
+                    + r['Buchungstag'][:2] + '/'
+                    + r['Buchungstag'][-4:],
+
+    # locale.atof does not actually know how to deal with German separators.
+    # So we do it the crude way
+    'amount': lambda r: r['Betrag'].replace('.', '').replace(',', '.'), 
     'desc': itemgetter('Buchungstext'),
     'payee': itemgetter('Auftraggeber/Empfänger'),
 }

--- a/csv2ofx/mappings/gls.py
+++ b/csv2ofx/mappings/gls.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from __future__ import absolute_import
 from operator import itemgetter
 


### PR DESCRIPTION
German GLS Bank outputs an awful CSV file in windows-1252 encoding. This is the mapping file that lets me import that into YNAB.

The command I use to do the conversion is the following:
`csv2ofx -E windows-1252 -m gls Zakelijk.csv Zakelijk.ofx`

To add to that, I have to perform this hot patch otherwise it does not work: https://github.com/reubano/csv2ofx/issues/26
I hope to be able to submit a fix for that in the following days.