### PR TITLE
handle shares when empty string

### DIFF
--- a/csv2ofx/mappings/mintapi.py
+++ b/csv2ofx/mappings/mintapi.py
@@ -27,6 +27,6 @@ mapping = {
     'bank': itemgetter('fi'),
     'currency': 'USD',
     'id': itemgetter('id'),
-    'shares': lambda tr: tr['shares'] if tr['shares'] is not '' else 0.0,
+    'shares': lambda tr: tr['shares'] if tr['shares'] != '' else 0.0,
     'symbol': itemgetter('symbol'),
 }

--- a/csv2ofx/mappings/mintapi.py
+++ b/csv2ofx/mappings/mintapi.py
@@ -27,6 +27,6 @@ mapping = {
     'bank': itemgetter('fi'),
     'currency': 'USD',
     'id': itemgetter('id'),
-    'shares': itemgetter('shares'),
+    'shares': lambda tr: tr['shares'] if tr['shares'] is not '' else 0.0,
     'symbol': itemgetter('symbol'),
 }


### PR DESCRIPTION
Sometimes shares is an empty string in the shares column data. This avoids an exception from attempting to convert the empty string to decimal.