### PR TITLE
Fix exit and ValueError exception as per #26 (1/2)

### DIFF
--- a/csv2ofx/main.py
+++ b/csv2ofx/main.py
@@ -24,7 +24,7 @@ import time
 import itertools as it
 import traceback
 
-from sys import stdin, stdout
+from sys import stdin, stdout, exit
 from importlib import import_module
 from imp import find_module, load_module
 from pkgutil import iter_modules
@@ -190,6 +190,10 @@ def run():  # noqa: C901
             msg += 'Check `start` and `end` options.'
         else:
             msg += 'Try again with `-c` option.'
+    except ValueError as err:
+        # csv2ofx called with no arguments or broken mapping
+        msg = 'Possible mapping problem: %s. ' % str(err)
+        parser.print_help()
     except Exception as err:  # pylint: disable=broad-except
         msg = 1
         traceback.print_exc()


### PR DESCRIPTION
Fixes `exit()` and `ValueError` exception handling as per part 1/2 in https://github.com/reubano/csv2ofx/issues/26#issuecomment-367771662