### PR TITLE
Change default date format to four digit year, which affects QIF files.

### DIFF
--- a/csv2ofx/__init__.py
+++ b/csv2ofx/__init__.py
@@ -45,7 +45,7 @@ __version__ = '0.27.0'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2015 Reuben Cummings'
 
-DEF_DATE_FMT = '%m/%d/%y'
+DEF_DATE_FMT = '%m/%d/%Y'
 
 # pylint: disable=invalid-name
 md5 = lambda content: hashlib.md5(content.encode('utf-8')).hexdigest()


### PR DESCRIPTION
Two digit years default to 19 as century when imported into Quicken, never right. This change makes them four digit so the century can be brought along into the QIF file. 