### PR TITLE
Add pyproject.toml so the project can build from source.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=36.2.4", "pkutils>=1.0.0,<2.0.0"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Fixes #86:

```
~ $ ~/.envs/csv2ofx/bin/pip install git+https://github.com/jaraco/csv2ofx@feature/build
Collecting git+https://github.com/jaraco/csv2ofx@feature/build
  Cloning https://github.com/jaraco/csv2ofx (to revision feature/build) to /private/var/folders/c6/v7hnmq453xb6p2dbz1gqc6rr0000gn/T/pip-req-build-87af42ur
  Running command git clone -q https://github.com/jaraco/csv2ofx /private/var/folders/c6/v7hnmq453xb6p2dbz1gqc6rr0000gn/T/pip-req-build-87af42ur
  Running command git checkout -b feature/build --track origin/feature/build
  Switched to a new branch 'feature/build'
  Branch 'feature/build' set up to track remote branch 'feature/build' from 'origin'.
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
    Preparing wheel metadata ... done
Collecting python-dateutil<3.0.0,>=2.7.2
  Using cached python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
Collecting requests<3.0.0,>=2.18.4
  Using cached requests-2.26.0-py2.py3-none-any.whl (62 kB)
Collecting meza<0.42.0,>=0.41.0
  Using cached meza-0.41.1-py2.py3-none-any.whl (56 kB)
Collecting pygogo<0.13.0,>=0.12.0
  Using cached pygogo-0.12.0-py2.py3-none-any.whl (21 kB)
Collecting ijson<3.0.0,>=2.3
  Using cached ijson-2.6.1-py3-none-any.whl
Collecting PyYAML<4.0.0,>=3.12
  Using cached PyYAML-3.13-cp38-cp38-macosx_10_9_x86_64.whl
Collecting beautifulsoup4<5.0.0,>=4.6.0
  Using cached beautifulsoup4-4.10.0-py3-none-any.whl (97 kB)
Collecting dbfread==2.0.4
  Using cached dbfread-2.0.4-py2.py3-none-any.whl (19 kB)
Collecting six<2.0.0,>=1.11.0
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting xlrd<2.0.0,>=1.1.0
  Using cached xlrd-1.2.0-py2.py3-none-any.whl (103 kB)
Collecting python-slugify<2.0.0,>=1.2.5
  Using cached python_slugify-1.2.6-py2.py3-none-any.whl
Collecting chardet<4.0.0,>=3.0.4
  Using cached chardet-3.0.4-py2.py3-none-any.whl (133 kB)
Collecting soupsieve>1.2
  Using cached soupsieve-2.3.1-py3-none-any.whl (37 kB)
Collecting Unidecode>=0.04.16
  Using cached Unidecode-1.3.2-py3-none-any.whl (235 kB)
Collecting urllib3<1.27,>=1.21.1
  Using cached urllib3-1.26.7-py2.py3-none-any.whl (138 kB)
Collecting charset-normalizer~=2.0.0
  Using cached charset_normalizer-2.0.9-py3-none-any.whl (39 kB)
Collecting idna<4,>=2.5
  Using cached idna-3.3-py3-none-any.whl (61 kB)
Collecting certifi>=2017.4.17
  Using cached certifi-2021.10.8-py2.py3-none-any.whl (149 kB)
Building wheels for collected packages: csv2ofx
  Building wheel for csv2ofx (PEP 517) ... done
  Created wheel for csv2ofx: filename=csv2ofx-0.27.0-py2.py3-none-any.whl size=35004 sha256=33e2ef4595f10399d250b930d27c5c92384e2ea56e406ec113b92f32e4899801
  Stored in directory: /private/var/folders/c6/v7hnmq453xb6p2dbz1gqc6rr0000gn/T/pip-ephem-wheel-cache-h80tl95f/wheels/be/62/09/c0882fd0aec580ec0d6136333d90643f822f474f2532d72d00
Successfully built csv2ofx
Installing collected packages: urllib3, Unidecode, soupsieve, six, idna, charset-normalizer, certifi, xlrd, requests, PyYAML, python-slugify, python-dateutil, pygogo, ijson, dbfread, chardet, beautifulsoup4, meza, csv2ofx
Successfully installed PyYAML-3.13 Unidecode-1.3.2 beautifulsoup4-4.10.0 certifi-2021.10.8 chardet-3.0.4 charset-normalizer-2.0.9 csv2ofx-0.27.0 dbfread-2.0.4 idna-3.3 ijson-2.6.1 meza-0.41.1 pygogo-0.12.0 python-dateutil-2.8.2 python-slugify-1.2.6 requests-2.26.0 six-1.16.0 soupsieve-2.3.1 urllib3-1.26.7 xlrd-1.2.0
WARNING: You are using pip version 21.1.1; however, version 21.3.1 is available.
You should consider upgrading via the '/Users/jaraco/.envs/csv2ofx/bin/python3.8 -m pip install --upgrade pip' command.
```