### PR TITLE
Change Categories to class over split

### DIFF
--- a/csv2ofx/mappings/mint.py
+++ b/csv2ofx/mappings/mint.py
@@ -12,7 +12,7 @@ from operator import itemgetter
 mapping = {
     "is_split": False,
     "has_header": True,
-    "split_account": itemgetter("Category"),
+    "class": itemgetter("Category"),
     "account": itemgetter("Account Name"),
     "date": itemgetter("Date"),
     "type": itemgetter("Transaction Type"),


### PR DESCRIPTION
When importing (homebank) each transaction would be added as a split.
This change imports the transaction with the correct category without a
split.