### PR TITLE
Allow mappings to specify custom_header

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ attribute | description | default field | default value | example
 attribute | description | default value | example
 ----------|-------------|---------------|--------
 `has_header`|does the csv file have a header row|True
+`custom_header`|header row to use (e.g. if not provided in csv)|None|["Account","Date","Amount"]
 `is_split`|does the csv file contain split (double entry) transactions|False
 `currency`|the currency ISO code|USD|GBP
 `delimiter`|the csv field delimiter|,|;

--- a/csv2ofx/main.py
+++ b/csv2ofx/main.py
@@ -238,6 +238,7 @@ def run():  # noqa: C901
 
     ckwargs = {
         "has_header": cont.has_header,
+        "custom_header": getattr(cont, "custom_header", None),
         "delimiter": mapping.get("delimiter", ","),
         "first_row": mapping.get("first_row", args.first_row),
         "last_row": mapping.get("last_row", args.last_row),


### PR DESCRIPTION
Enables easier parsing of CSV's without headers.

Confirmed all tests are passing (by manually running ./tests/test.py -- for some reason, manage lint hangs for me and manage test throws a AttributeError: module 'collections' has no attribute 'Callable' error for me now).

Once this is merged, I will start another PR that uses this feature in the Schwab Bank mapping (to extract the account_id from the first line of the CSV file).  You can preview the changes by looking at my [schwab-account-id](https://github.com/tstabrawa/csv2ofx/compare/custom_header...tstabrawa:csv2ofx:schwab-account-id) branch.