### PR TITLE
Adopt ruff for linting and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![GHA](https://github.com/PROJECT_PATH/actions/workflows/main.yml/badge.svg)](https://github.com/PROJECT_PATH/actions?query=workflow%3A%22tests%22)
 [![versions](https://img.shields.io/pypi/pyversions/csv2ofx.svg)](https://pypi.python.org/pypi/csv2ofx)
 [![pypi](https://img.shields.io/pypi/v/csv2ofx.svg)](https://pypi.python.org/pypi/csv2ofx)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 ## INTRODUCTION
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,6 @@
 import os
 import platform
 
-
 is_GitHub_Linux = bool(
     os.environ.get("GITHUB_ACTIONS") and platform.system() == "Linux"
 )

--- a/csv2ofx/__init__.py
+++ b/csv2ofx/__init__.py
@@ -18,17 +18,13 @@ Attributes:
 """
 
 import hashlib
-import itertools as it
-
-from functools import partial
 from datetime import datetime as dt
-from operator import itemgetter
 from decimal import Decimal
+from functools import partial
 
-from builtins import *
-from six.moves import filterfalse
-from meza.process import merge, group
 from dateutil.parser import parse
+from meza.process import group, merge
+from six.moves import filterfalse
 
 from . import utils
 
@@ -43,7 +39,8 @@ __copyright__ = "Copyright 2015 Reuben Cummings"
 
 
 # pylint: disable=invalid-name
-md5 = lambda content: hashlib.md5(content.encode("utf-8")).hexdigest()
+def md5(content):
+    return hashlib.md5(content.encode("utf-8")).hexdigest()
 
 
 class BalanceError(Exception):
@@ -307,7 +304,10 @@ class Content(object):  # pylint: disable=too-many-instance-attributes
             if self.is_split and collapse:
                 # group transactions by `collapse` field and sum the amounts
                 byaccount = group(transactions, collapse)
-                oprtn = lambda values: sum(map(utils.convert_amount, values))
+
+                def oprtn(values):
+                    return sum(map(utils.convert_amount, values))
+
                 merger = partial(merge, pred=self.amount, op=oprtn)
                 trxns = [merger(dicts) for _, dicts in byaccount]
             else:
@@ -336,6 +336,8 @@ class Content(object):  # pylint: disable=too-many-instance-attributes
                 main_pos = 0
 
             # pylint: disable=cell-var-from-loop
-            keyfunc = lambda enum: enum[0] != main_pos
+            def keyfunc(enum):
+                return enum[0] != main_pos
+
             sorted_trxns = sorted(enumerate(filtered_trxns), key=keyfunc)
             yield (grp, main_pos, sorted_trxns)

--- a/csv2ofx/__main__.py
+++ b/csv2ofx/__main__.py
@@ -1,4 +1,3 @@
 from . import main
 
-
 __name__ == "__main__" and main.run()

--- a/csv2ofx/main.py
+++ b/csv2ofx/main.py
@@ -17,34 +17,31 @@ Attributes:
     ENCODING (str): Default file encoding.
 """
 
-import time
 import itertools as it
+import time
 import traceback
-
-from sys import stdin, stdout, exit
+from argparse import ArgumentParser, RawTextHelpFormatter
+from datetime import datetime as dt
 from importlib import import_module, util
-from pkgutil import iter_modules
+from io import open
+from math import inf
 from operator import itemgetter
 from os import path as p
-from io import open
-from datetime import datetime as dt
-from argparse import RawTextHelpFormatter, ArgumentParser
+from pkgutil import iter_modules
 from pprint import pprint
-from math import inf
+from sys import exit, stdin, stdout
 
 try:
     FileNotFoundError
 except NameError:
     FileNotFoundError = IOError
 
-from builtins import *
 from dateutil.parser import parse
-from meza.io import read_csv, IterStringIO, write
+from meza.io import IterStringIO, read_csv, write
 
 from . import BalanceError, utils
 from .ofx import OFX
 from .qif import QIF
-
 
 parser = ArgumentParser(  # pylint: disable=invalid-name
     description="description: csv2ofx converts a csv file to ofx and qif",

--- a/csv2ofx/mappings/amazon.py
+++ b/csv2ofx/mappings/amazon.py
@@ -16,10 +16,9 @@ Honors some environment variables:
    account. If unspecified, defaults to "100000001".
 """
 
-import os
 import functools
+import os
 from operator import itemgetter
-
 
 All = ['']
 """

--- a/csv2ofx/mappings/boursorama.py
+++ b/csv2ofx/mappings/boursorama.py
@@ -1,6 +1,5 @@
 from operator import itemgetter
 
-
 mapping = {
     "has_header": True,
     "is_split": False,

--- a/csv2ofx/mappings/ingdirect.py
+++ b/csv2ofx/mappings/ingdirect.py
@@ -8,6 +8,7 @@ csv2ofx.mappings.ingdirect
 Provides a mapping for transactions obtained via ING Direct
 (Australian bank)
 """
+
 from operator import itemgetter
 
 mapping = {

--- a/csv2ofx/mappings/ingesp.py
+++ b/csv2ofx/mappings/ingesp.py
@@ -8,9 +8,10 @@ csv2ofx.mappings.ingdirect
 Provides a mapping for transactions obtained via ING Direct
 (Spanish bank)
 """
-from operator import itemgetter
-import json
+
 import hashlib
+import json
+from operator import itemgetter
 
 
 def find_type(transaction):
@@ -27,10 +28,18 @@ def gen_transaction_id(transaction):
 
 def get_payee(transaction):
     cadena = transaction.get('desc')
-    subcadenas = ['Abono por campaña', 'Devolución Tarjeta', 
-               'Nomina recibida', 'Traspaso recibido', 'Pago en', 
-               'Recibo', 'Reintegro efectivo', 'Transferencia Bizum emitida', 
-               'Transferencia emitida a', 'Transferencia recibida de']
+    subcadenas = [
+        'Abono por campaña',
+        'Devolución Tarjeta',
+        'Nomina recibida',
+        'Traspaso recibido',
+        'Pago en',
+        'Recibo',
+        'Reintegro efectivo',
+        'Transferencia Bizum emitida',
+        'Transferencia emitida a',
+        'Transferencia recibida de',
+    ]
     for subcadena in subcadenas:
         if subcadena in cadena:
             payee = cadena.replace(subcadena, '')
@@ -42,10 +51,18 @@ def get_payee(transaction):
 
 def get_transaction_type(transaction):
     cadena = transaction.get('desc')
-    subcadenas = ['Abono por campaña', 'Devolución Tarjeta', 
-               'Nomina recibida', 'Traspaso recibido', 'Pago en', 
-               'Recibo', 'Reintegro efectivo', 'Transferencia Bizum emitida', 
-               'Transferencia emitida a', 'Transferencia recibida de']
+    subcadenas = [
+        'Abono por campaña',
+        'Devolución Tarjeta',
+        'Nomina recibida',
+        'Traspaso recibido',
+        'Pago en',
+        'Recibo',
+        'Reintegro efectivo',
+        'Transferencia Bizum emitida',
+        'Transferencia emitida a',
+        'Transferencia recibida de',
+    ]
     for subcadena in subcadenas:
         if subcadena in cadena:
             notes = subcadena
@@ -67,4 +84,3 @@ mapping = {
     "class": itemgetter("class"),
     "id": gen_transaction_id,
 }
-

--- a/csv2ofx/mappings/mdb.py
+++ b/csv2ofx/mappings/mdb.py
@@ -7,6 +7,7 @@ csv2ofx.mappings.mdb
 
 Provides a mapping for transactions obtained via moneydashboard.com
 """
+
 from operator import itemgetter
 
 mapping = {

--- a/csv2ofx/mappings/mint.py
+++ b/csv2ofx/mappings/mint.py
@@ -7,6 +7,7 @@ csv2ofx.mappings.mintapi
 
 Provides a mapping for transactions obtained via mint.com
 """
+
 from operator import itemgetter
 
 mapping = {

--- a/csv2ofx/mappings/mint_extra.py
+++ b/csv2ofx/mappings/mint_extra.py
@@ -7,9 +7,10 @@ csv2ofx.mappings.mintapi
 
 Provides a mapping for transactions obtained via mint.com
 """
-from operator import itemgetter
-from csv2ofx.utils import convert_amount
 
+from operator import itemgetter
+
+from csv2ofx.utils import convert_amount
 
 mapping = {
     "is_split": False,

--- a/csv2ofx/mappings/mint_headerless.py
+++ b/csv2ofx/mappings/mint_headerless.py
@@ -7,6 +7,7 @@ csv2ofx.mappings.mint_headerless
 
 Provides a mapping for transactions obtained via mint.com
 """
+
 from operator import itemgetter
 
 mapping = {

--- a/csv2ofx/mappings/mintapi.py
+++ b/csv2ofx/mappings/mintapi.py
@@ -7,6 +7,7 @@ csv2ofx.mappings.mintapi
 
 Provides a mapping for transactions obtained via the mintapi python script
 """
+
 from operator import itemgetter
 
 mapping = {

--- a/csv2ofx/mappings/n26.py
+++ b/csv2ofx/mappings/n26.py
@@ -1,6 +1,6 @@
-from operator import itemgetter
-import json
 import hashlib
+import json
+from operator import itemgetter
 
 
 def find_type(transaction):

--- a/csv2ofx/mappings/outbank.py
+++ b/csv2ofx/mappings/outbank.py
@@ -8,6 +8,7 @@ Provides a mapping for transactions obtained from Outbank, a
 banking application that is able to export to CSV.
 Mapping build for version 2.19.
 """
+
 from operator import itemgetter
 
 mapping = {

--- a/csv2ofx/mappings/payoneer.py
+++ b/csv2ofx/mappings/payoneer.py
@@ -1,6 +1,6 @@
 import os
-from operator import itemgetter
 from datetime import datetime
+from operator import itemgetter
 
 
 def is_credit(row):

--- a/csv2ofx/mappings/pcmastercard.py
+++ b/csv2ofx/mappings/pcmastercard.py
@@ -2,6 +2,7 @@
 For PC Financial Mastercards
 https://www.pcfinancial.ca/en/credit-cards
 """
+
 from operator import itemgetter
 
 mapping = {

--- a/csv2ofx/mappings/schwabchecking.py
+++ b/csv2ofx/mappings/schwabchecking.py
@@ -1,8 +1,4 @@
-from __future__ import (
-    absolute_import, division, print_function, unicode_literals)
-
 from operator import itemgetter
-import re
 
 mapping = {
     'has_header': True,

--- a/csv2ofx/mappings/stripe.py
+++ b/csv2ofx/mappings/stripe.py
@@ -15,6 +15,7 @@ It's suggested the All Columns format be used if not all transactions
 identify a customer. This mapping sets PAYEE to Customer Name if it
 exists, otherwise Card Name (if provided)
 """
+
 from operator import itemgetter
 
 mapping = {

--- a/csv2ofx/mappings/ubs-ch-fr.py
+++ b/csv2ofx/mappings/ubs-ch-fr.py
@@ -21,11 +21,12 @@ tricky:
 * The payee is not explicitly provided: it can be in columns "Description 2/3"
 
 """
-from operator import itemgetter
 
 # Financial numbers are expressed as "2'045.56" in de/fr/it_CH (utf8 has some
 # glitches, so we go for the default one)
 import locale
+from operator import itemgetter
+
 locale.setlocale(locale.LC_NUMERIC, 'fr_CH')
 
 __author__ = 'Marco "sphakka" Poleggi'

--- a/csv2ofx/ofx.py
+++ b/csv2ofx/ofx.py
@@ -17,9 +17,9 @@ Examples:
 Attributes:
     ENCODING (str): Default file encoding.
 """
+
 from datetime import datetime as dt
 
-from builtins import *
 from meza.fntools import chunk, xmlize
 from meza.process import group
 
@@ -246,19 +246,15 @@ ENCODING:USASCIICHARSET:1252COMPRESSION:NONEOLDFILEUID:NONENEWFILEUID:NONE\
             # world. In the example above, a <DTPOSTED>20000505120000 would
             # always display as 5/5/00 anywhere the world except for the
             # center of the Pacific Ocean."
-            kwargs.update(
-                {
-                    "start_date": self.start.strftime("%Y%m%d120000"),
-                    "end_date": self.end.strftime("%Y%m%d120000"),
-                }
-            )
+            kwargs.update({
+                "start_date": self.start.strftime("%Y%m%d120000"),
+                "end_date": self.end.strftime("%Y%m%d120000"),
+            })
         else:
-            kwargs.update(
-                {
-                    "start_date": self.start.strftime("%Y%m%d"),
-                    "end_date": self.end.strftime("%Y%m%d"),
-                }
-            )
+            kwargs.update({
+                "start_date": self.start.strftime("%Y%m%d"),
+                "end_date": self.end.strftime("%Y%m%d"),
+            })
 
         content = "\t\t\t<STMTRS>\n"
         content += "\t\t\t\t<CURDEF>%(currency)s</CURDEF>\n" % kwargs
@@ -308,8 +304,9 @@ ENCODING:USASCIICHARSET:1252COMPRESSION:NONEOLDFILEUID:NONENEWFILEUID:NONE\
         content += "\t\t\t\t\t\t<TRNAMT>%(amount)0.2f</TRNAMT>\n" % kwargs
         content += "\t\t\t\t\t\t<FITID>%(id)s</FITID>\n" % kwargs
 
-        if (self.ms_money and kwargs.get("check_num")) or \
-           (not self.ms_money and kwargs.get("check_num") is not None):
+        if (self.ms_money and kwargs.get("check_num")) or (
+            not self.ms_money and kwargs.get("check_num") is not None
+        ):
             extra = "\t\t\t\t\t\t<CHECKNUM>%(check_num)s</CHECKNUM>\n"
             content += extra % kwargs
 
@@ -356,20 +353,20 @@ ENCODING:USASCIICHARSET:1252COMPRESSION:NONEOLDFILEUID:NONENEWFILEUID:NONE\
         # 6. If more balances are consistent with descending order, use the
         #    first transaction.
         # 7. Don't get ending balance from transactions.
-        if self.latest_date_count == 1:                                 # (1)
+        if self.latest_date_count == 1:  # (1)
             endbaltrxn = self.latest_trxn
-        elif self.dates_ascending and self.dates_descending:            # (2)
+        elif self.dates_ascending and self.dates_descending:  # (2)
             reason = "transactions have both ascending and descending dates"
             endbaltrxn = None
-        elif self.dates_ascending:                                      # (3)
+        elif self.dates_ascending:  # (3)
             endbaltrxn = self.last_trxn
-        elif self.dates_descending:                                     # (4)
+        elif self.dates_descending:  # (4)
             endbaltrxn = self.first_trxn
-        elif self.balances_ascending > self.balances_descending:        # (5)
+        elif self.balances_ascending > self.balances_descending:  # (5)
             endbaltrxn = self.last_trxn
-        elif self.balances_descending > self.balances_ascending:        # (6)
+        elif self.balances_descending > self.balances_ascending:  # (6)
             endbaltrxn = self.first_trxn
-        else:                                                           # (7)
+        else:  # (7)
             reason = "not enough information to determine ending balance"
             endbaltrxn = None
 
@@ -726,12 +723,10 @@ ENCODING:USASCIICHARSET:1252COMPRESSION:NONEOLDFILEUID:NONENEWFILEUID:NONE\
             2
         """
         # Note: Both of these could be true for a given transaction pair
-        if self.last_trxn["balance"] + trxn['amount'] == \
-                trxn['balance']:
+        if self.last_trxn["balance"] + trxn['amount'] == trxn['balance']:
             # Balances appear consistent with ascending transaction order
             self.balances_ascending += 1
-        if trxn.get("balance") + self.last_trxn['amount'] == \
-                self.last_trxn['balance']:
+        if trxn.get("balance") + self.last_trxn['amount'] == self.last_trxn['balance']:
             # Balances appear consistent with descending transaction order
             self.balances_descending += 1
 

--- a/csv2ofx/qif.py
+++ b/csv2ofx/qif.py
@@ -17,7 +17,7 @@ Examples:
 Attributes:
     ENCODING (str): Default file encoding.
 """
-from builtins import *
+
 from meza.fntools import chunk
 from meza.process import group
 
@@ -188,7 +188,7 @@ class QIF(Content):
             >>> trxn == result.replace('\\n', '').replace('\\t', '')
             True
         """
-        date_fmt = kwargs.get("date_fmt", self.date_fmt)
+        kwargs.get("date_fmt", self.date_fmt)
         kwargs.update({"time_stamp": kwargs["date"].strftime("%m/%d/%Y")})
         is_investment = kwargs.get("is_investment")
         is_transaction = not is_investment

--- a/csv2ofx/utils.py
+++ b/csv2ofx/utils.py
@@ -17,32 +17,30 @@ Attributes:
     ENCODING (str): Default file encoding.
 """
 
-from builtins import *
-from meza.fntools import get_separators
-from meza.convert import to_decimal
 from collections import OrderedDict
+
+from meza.convert import to_decimal
+from meza.fntools import get_separators
 
 # NOTE: Because we are testing for substrings, the order we iterate
 # over this dictionary matters (so place strings like "reinvest"
 # above substrings like "invest")
-ACTION_TYPES = OrderedDict(
-    [
-        ("ShrsIn", ("deposit",)),
-        ("ShrsOut", ("withdraw",)),
-        ("ReinvDiv", ("reinvest",)),
+ACTION_TYPES = OrderedDict([
+    ("ShrsIn", ("deposit",)),
+    ("ShrsOut", ("withdraw",)),
+    ("ReinvDiv", ("reinvest",)),
+    (
+        "Buy",
         (
-            "Buy",
-            (
-                "buy",
-                "invest",
-            ),
+            "buy",
+            "invest",
         ),
-        ("Div", ("dividend",)),
-        ("Int", ("interest",)),
-        ("Sell", ("sell",)),
-        ("StkSplit", ("split",)),
-    ]
-)
+    ),
+    ("Div", ("dividend",)),
+    ("Int", ("interest",)),
+    ("Sell", ("sell",)),
+    ("StkSplit", ("split",)),
+])
 
 TRANSFERABLE = {"Buy", "Div", "Int", "Sell"}
 
@@ -144,7 +142,10 @@ def get_max_split(splits, keyfunc):
         >>> get_max_split(splits, itemgetter('amount')) == (0, {'amount': 350})
         True
     """
-    maxfunc = lambda enum: abs(keyfunc(enum[1]))
+
+    def maxfunc(enum):
+        return abs(keyfunc(enum[1]))
+
     return max(enumerate(splits), key=maxfunc)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ csv2ofx = "csv2ofx.main:run"
 test = [
 	"pygogo>=0.13.2,<2.0.0",
 	"pytest",
+	"pytest-enabler",
+	"pytest-ruff",
 ]
 
 [tool.setuptools.dynamic]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,55 @@
+# extend pyproject.toml for requires-python (workaround astral-sh/ruff#10299)
+extend = "pyproject.toml"
+
+[lint]
+extend-select = [
+	# upstream
+ 
+	"C901", # complex-structure
+	"I", # isort
+	"PERF401", # manual-list-comprehension
+	"W", # pycodestyle Warning
+ 
+ 	# Ensure modern type annotation syntax and best practices
+	# Not including those covered by type-checkers or exclusive to Python 3.11+
+	"FA", # flake8-future-annotations
+	"F404", # late-future-import
+	"PYI", # flake8-pyi
+	"UP006", # non-pep585-annotation
+	"UP007", # non-pep604-annotation
+	"UP010", # unnecessary-future-import
+	"UP035", # deprecated-import
+	"UP037", # quoted-annotation
+	"UP043", # unnecessary-default-type-args
+
+	# local
+]
+ignore = [
+	# upstream
+ 
+	# Typeshed rejects complex or non-literal defaults for maintenance and testing reasons,
+	# irrelevant to this project.
+	"PYI011", # typed-argument-default-in-stub
+	# https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+	"W191",
+	"E111",
+	"E114",
+	"E117",
+	"D206",
+	"D300",
+	"Q000",
+	"Q001",
+	"Q002",
+	"Q003",
+	"COM812",
+	"COM819",
+
+ 	# local
+]
+
+[format]
+# Enable preview to get hugged parenthesis unwrapping and other nice surprises
+# See https://github.com/jaraco/skeleton/pull/133#issuecomment-2239538373
+preview = true
+# https://docs.astral.sh/ruff/settings/#format_quote-style
+quote-style = "preserve"

--- a/tests/test.py
+++ b/tests/test.py
@@ -14,10 +14,9 @@ import os
 import shlex
 import subprocess
 import sys
-
 from difflib import unified_diff
-from os import path as p
 from io import StringIO, open
+from os import path as p
 from timeit import default_timer as timer
 
 import pygogo as gogo


### PR DESCRIPTION
In recent commits, pylint and flake8 and black were removed. This PR restores linting using the modern, popular, fast ruff formatter.

This change adopts the configuration from jaraco/skeleton, where I and other members of the community work to maintain best practices for tooling while also aiming for the minimal useful configuration and relying on defaults where possible.

By using pytest-ruff, the checks are run automatically as part of running the test suite. Those checks can be suppressed by passing `-p no:ruff` to pytest.

- **Add ruff.toml as found in jaraco/skeleton.**
- **Apply ruff formatting and fixes.**
- **Add pytest-ruff and pytest-enabler, enforcing lint checks in tests.**
- **add a badge for Ruff.**
