### PR TITLE
Support pending transactions in Amazon exports

### DIFF
--- a/csv2ofx/__init__.py
+++ b/csv2ofx/__init__.py
@@ -163,8 +163,16 @@ class Content:  # pylint: disable=too-many-instance-attributes
             >>> Content(mapping, start=dt(2013, 1, 1)).include(trxn)
             False
         """
-        keep = self.end >= self.parse_date(trxn) >= self.start
-        return keep and self.filter(trxn)
+        return all(
+            filter_(trxn)
+            for filter_ in (
+                self.in_range,
+                self.filter,
+            )
+        )
+
+    def in_range(self, trxn):
+        return self.start <= self.parse_date(trxn) <= self.end
 
     def convert_amount(self, trxn):
         """Converts a string amount into a number

--- a/csv2ofx/__init__.py
+++ b/csv2ofx/__init__.py
@@ -67,7 +67,7 @@ class Content:  # pylint: disable=too-many-instance-attributes
         self.account = "N/A"
         self.parse_fmt = kwargs.get("parse_fmt")
         self.dayfirst = kwargs.get("dayfirst")
-        self.filter = kwargs.get("filter")
+        self.filter = kwargs.get("filter") or bool
         self.ms_money = kwargs.get("ms_money")
         self.split_account = None
         self.inv_split_account = None
@@ -164,7 +164,7 @@ class Content:  # pylint: disable=too-many-instance-attributes
             False
         """
         keep = self.end >= self.parse_date(trxn) >= self.start
-        return self.filter(trxn) if keep and self.filter else keep
+        return keep and self.filter(trxn)
 
     def convert_amount(self, trxn):
         """Converts a string amount into a number

--- a/csv2ofx/__init__.py
+++ b/csv2ofx/__init__.py
@@ -166,8 +166,8 @@ class Content:  # pylint: disable=too-many-instance-attributes
         return all(
             filter_(trxn)
             for filter_ in (
-                self.in_range,
                 self.filter,
+                self.in_range,
             )
         )
 

--- a/csv2ofx/mappings/amazon.py
+++ b/csv2ofx/mappings/amazon.py
@@ -44,6 +44,14 @@ def filter_payment(row):
     return include and not exclude
 
 
+def filter_pending(row):
+    return row['date'] != 'pending'
+
+
+def filter(row):
+    return filter_pending(row) and filter_payment(row)
+
+
 mapping = {
     'has_header': True,
     'delimiter': ',',
@@ -56,5 +64,5 @@ mapping = {
     'id': itemgetter('order id'),
     'type': 'DEBIT',
     'last_row': -1,
-    'filter': filter_payment,
+    'filter': filter,
 }

--- a/data/test/amazon.csv
+++ b/data/test/amazon.csv
@@ -1,5 +1,7 @@
-order id,items,to,date,total,shipping,shipping_refund,gift,tax,refund,payments
-112-1635210-7125801,"Goof Off Household Heavy Duty Remover, 4 fl. oz. Spray, For Spots, Stains, Marks, and Messes; ",John Doe,2022-12-20,4.22,0,0,0,0.24,0,"Visa ending in 1234: December 24, 2022: $4.22; "
-111-3273904-8117030,"Darksteve - Violet Decorative Light Bulb - Edison Light Bulb, Antique Vintage Style Light, G80 Size, E26 Base, Non-Dimmable (3w/110v); ",John Doe,2022-12-20,7.42,0,0,0,0.42,0,"Visa ending in 5566: December 28, 2022: $7.42; "
-114-5269613-6941034,"TOPGREENER Smart Wi-Fi In-Wall Tamper Resistant Dual USB Charger Outlet, Energy Monitoring, Compatible with Amazon Alexa and Google Assistant, Outlet; ",John Doe,2022-10-11,34.12,0,0,0,1.93,0,"Visa ending in 9876: October 12, 2022: $34.12; "
-order id,items,to,date,total,shipping,shipping_refund,gift,tax,refund,payments
+order id,order url,items,to,date,total,shipping,shipping_refund,gift,tax,refund,payments
+112-1635210-7125801,https://www.amazon.com/...,"Goof Off Household Heavy Duty Remover, 4 fl. oz. Spray, For Spots, Stains, Marks, and Messes; ",John Doe,2022-12-20,4.22,0,0,0,0.24,0,"Visa ending in 1234: December 24, 2022: $4.22; "
+111-3273904-8117030,https://www.amazon.com/...,"Darksteve - Violet Decorative Light Bulb - Edison Light Bulb, Antique Vintage Style Light, G80 Size, E26 Base, Non-Dimmable (3w/110v); ",John Doe,2022-12-20,7.42,0,0,0,0.42,0,"Visa ending in 5566: December 28, 2022: $7.42; "
+114-5269613-6941034,https://www.amazon.com/...,"TOPGREENER Smart Wi-Fi In-Wall Tamper Resistant Dual USB Charger Outlet, Energy Monitoring, Compatible with Amazon Alexa and Google Assistant, Outlet; ",John Doe,2022-10-11,34.12,0,0,0,1.93,0,"Visa ending in 9876: October 12, 2022: $34.12; "
+D01-1234567-8901234,https://www.amazon.com/...,,,pending,,,,,,,
+D01-5678901-2345678,https://www.amazon.com/...,,,pending,,,,,,,
+order id,order url,items,to,date,total,shipping,shipping_refund,gift,tax,refund,payments


### PR DESCRIPTION
- **Replace `Content.skip_transaction` with `Content.include(transaction)`.**
- **Give `Content.filter` a degenerate default so it's never None.**
- **Rewrite `Content.include` as a series of filters.**
- **Give precedence to the custom filter so it may filter out transactions with an invalid date.**
- **Add pending transactions and 'order url' field as found in recent exports.**
- **Update mapping to filter out 'pending' transactions.**

Closes #143

The first three commits do some refactoring to make transaction filtering more regular between the mapping-supplied filter and the built-in date-range filter without changing any behavior.

The fourth commit changes the behavior to give precedence to the custom filter.

The fifth commit updates the tests to reflect the new use-cases found in recent exports, revealing the failed expectation (test fails).

And finally, the sixth commit updates the mapping to filter out those pending transactions.
