### PR TITLE
Remove the enumerated tox envs.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,8 +54,6 @@ jobs:
           platform: ubuntu-latest
     runs-on: ${{ matrix.platform }}
     continue-on-error: ${{ matrix.python == '3.14' }}
-    env:
-      TOX_ENV: py
     steps:
       - uses: actions/checkout@v4
       - name: Install build dependencies

--- a/README.md
+++ b/README.md
@@ -255,13 +255,9 @@ Either install [tox](https://tox.wiki) or install [pipx](https://pipx.pypa.io) a
 tox
 ```
 
-Tox will run the tests and other checks (linter) in different Python environments. It will create Python environments in `.tox/*` (e.g. `.tox/py313`) and install csv2ofx there. To run in just the main python environment:
+Tox will run the tests and other checks (linter) in different Python environments. It will create a Python environment in `.tox/py` and install csv2ofx there.
 
-```bash
-tox -e py
-```
-
-Feel free to activate one of those environments or create a separate one.
+Feel free to activate that environment or create a separate one.
 
 3. Create a branch for local development
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,3 @@
-[tox]
-envlist=py{39,310,311,312,313,314,py3}
-
-
 [testenv]
 setenv =
   PYTHONHASHSEED=94967295


### PR DESCRIPTION
This approach adopts the default tox behavior of running the tests in the same Python environment as where tox was installed. This approach has a few advantages:

- Each invocation results in a single test run irrespective of the number of Pythons installed on their system.
- The tests run under what is likely to be the user's preferred Python environment.
- Users can still easily opt into another environment with an explicit invocation (e.g. `tox -e py312` or `env TOX_ENV=py312 tox`).
- The prior behavior can be revived by any particular user by setting `TOX_ENV=py39,py310,py311,py312,py313,py314,pypy3`.
- Any contributors will still go through CI to check the project across supported Python versions and platforms, so in the rare case that a bug exists not in the developer's environment, it will still be caught fairly early.
- Less config means fewer deviations from the default behaviors and fewer concerns to maintain as the ecosystem evolves.

Note that this config doesn't affect me personally, because I set `TOX_ENV=py` in my development environment to get this behavior in repos that supply this list of envs, but even for me, it's nice not to have to see or think about the config.
