### PR TITLE
Freeze time in sample checks

### DIFF
--- a/csv2ofx/main.py
+++ b/csv2ofx/main.py
@@ -194,11 +194,10 @@ parser.add_argument(
     "-v", "--verbose", help="verbose output", action="store_true", default=False
 )
 
-args = parser.parse_args()  # pylint: disable=C0103
 
-
-def run():  # noqa: C901
+def run(args=None):  # noqa: C901
     """Parses the CLI options and runs the main program"""
+    args = parser.parse_args(args)
     if args.debug:
         pprint(dict(args._get_kwargs()))  # pylint: disable=W0212
         exit(0)

--- a/csv2ofx/main.py
+++ b/csv2ofx/main.py
@@ -17,6 +17,7 @@ Attributes:
 """
 
 import itertools as it
+import os.path
 import sys
 import time
 import traceback
@@ -25,7 +26,6 @@ from datetime import datetime as dt
 from importlib import import_module, util
 from math import inf
 from operator import itemgetter
-from os import path as p
 from pkgutil import iter_modules
 from pprint import pprint
 
@@ -196,7 +196,7 @@ parser.add_argument(
 
 
 def _time_from_file(path):
-    return p.getmtime(path)
+    return os.path.getmtime(path)
 
 
 def run(args=None):  # noqa: C901
@@ -217,7 +217,7 @@ def run(args=None):  # noqa: C901
         sys.exit(0)
 
     if args.custom:
-        name = p.splitext(p.split(args.custom)[1])[0]
+        name = os.path.splitext(os.path.split(args.custom)[1])[0]
         spec = util.spec_from_file_location(name, args.custom)
         module = util.module_from_spec(spec)
         spec.loader.exec_module(module)

--- a/csv2ofx/main.py
+++ b/csv2ofx/main.py
@@ -195,6 +195,10 @@ parser.add_argument(
 )
 
 
+def _time_from_file(path):
+    return p.getmtime(path)
+
+
 def run(args=None):  # noqa: C901
     """Parses the CLI options and runs the main program"""
     args = parser.parse_args(args)
@@ -255,7 +259,7 @@ def run(args=None):  # noqa: C901
             server_date = parse(args.server_date, dayfirst=args.dayfirst)
         else:
             try:
-                mtime = p.getmtime(source.name)
+                mtime = _time_from_file(source.name)
             except (AttributeError, FileNotFoundError):
                 mtime = time.time()
 

--- a/csv2ofx/main.py
+++ b/csv2ofx/main.py
@@ -271,7 +271,7 @@ def run(args=None):  # noqa: C901
             "encoding": args.encoding,
         }
     except Exception as err:  # pylint: disable=broad-except
-        source.close()
+        source.close() if args.source else None
         sys.exit(err)
 
     dest = (
@@ -303,9 +303,9 @@ def run(args=None):  # noqa: C901
     else:
         msg = 0 if res else "No data to write. Check `start` and `end` options."
     finally:
-        sys.exit(msg)
         source.close() if args.source else None
         dest.close() if args.dest else None
+        sys.exit(msg)
 
 
 if __name__ == "__main__":

--- a/csv2ofx/main.py
+++ b/csv2ofx/main.py
@@ -17,6 +17,7 @@ Attributes:
 """
 
 import itertools as it
+import sys
 import time
 import traceback
 from argparse import ArgumentParser, RawTextHelpFormatter
@@ -27,7 +28,6 @@ from operator import itemgetter
 from os import path as p
 from pkgutil import iter_modules
 from pprint import pprint
-from sys import exit, stdin, stdout
 
 try:
     FileNotFoundError
@@ -200,17 +200,17 @@ def run(args=None):  # noqa: C901
     args = parser.parse_args(args)
     if args.debug:
         pprint(dict(args._get_kwargs()))  # pylint: disable=W0212
-        exit(0)
+        sys.exit(0)
 
     if args.version:
         from . import __version__ as version
 
         print(f"v{version}")
-        exit(0)
+        sys.exit(0)
 
     if args.list_mappings:
         print(", ".join(MODULES))
-        exit(0)
+        sys.exit(0)
 
     if args.custom:
         name = p.splitext(p.split(args.custom)[1])[0]
@@ -231,7 +231,7 @@ def run(args=None):  # noqa: C901
 
     cont = QIF(mapping, **okwargs) if args.qif else OFX(mapping, **okwargs)
     source = (
-        builtins.open(args.source, encoding=args.encoding) if args.source else stdin
+        builtins.open(args.source, encoding=args.encoding) if args.source else sys.stdin
     )
 
     ckwargs = {
@@ -272,10 +272,12 @@ def run(args=None):  # noqa: C901
         }
     except Exception as err:  # pylint: disable=broad-except
         source.close()
-        exit(err)
+        sys.exit(err)
 
     dest = (
-        builtins.open(args.dest, "w", encoding=args.encoding) if args.dest else stdout
+        builtins.open(args.dest, "w", encoding=args.encoding)
+        if args.dest
+        else sys.stdout
     )
 
     try:
@@ -301,7 +303,7 @@ def run(args=None):  # noqa: C901
     else:
         msg = 0 if res else "No data to write. Check `start` and `end` options."
     finally:
-        exit(msg)
+        sys.exit(msg)
         source.close() if args.source else None
         dest.close() if args.dest else None
 

--- a/csv2ofx/ofx.py
+++ b/csv2ofx/ofx.py
@@ -17,7 +17,7 @@ Attributes:
     ENCODING (str): Default file encoding.
 """
 
-from datetime import datetime as dt
+import datetime
 
 from meza.fntools import chunk, xmlize
 from meza.process import group
@@ -75,7 +75,7 @@ class OFX(Content):
             (str): the OFX content
 
         Examples:
-            >>> kwargs = {'date': dt(2012, 1, 15)}
+            >>> kwargs = {'date': datetime.datetime(2012, 1, 15)}
             >>> header = 'DATA:OFXSGMLENCODING:UTF-8<OFX><SIGNONMSGSRSV1>\
 <SONRS><STATUS><CODE>0</CODE><SEVERITY>INFO</SEVERITY></STATUS><DTSERVER>\
 20120115000000</DTSERVER><LANGUAGE>ENG</LANGUAGE></SONRS></SIGNONMSGSRSV1>\
@@ -101,7 +101,9 @@ ENCODING:USASCIICHARSET:1252COMPRESSION:NONEOLDFILEUID:NONENEWFILEUID:NONE\
         kwargs.setdefault("language", "ENG")
 
         # yyyymmddhhmmss
-        time_stamp = kwargs.get("date", dt.now()).strftime("%Y%m%d%H%M%S")
+        time_stamp = kwargs.get("date", datetime.datetime.now()).strftime(
+            "%Y%m%d%H%M%S"
+        )
 
         content = ""
         if self.ms_money:
@@ -150,7 +152,6 @@ ENCODING:USASCIICHARSET:1252COMPRESSION:NONEOLDFILEUID:NONENEWFILEUID:NONE\
             (dict): the OFX transaction data
 
         Examples:
-            >>> import datetime
             >>> from csv2ofx.mappings.mint import mapping
             >>> from decimal import Decimal
             >>> trxn = {
@@ -169,7 +170,7 @@ ENCODING:USASCIICHARSET:1252COMPRESSION:NONEOLDFILEUID:NONENEWFILEUID:NONE\
             ...     'memo': 'description notes',
             ...     'id': 'ee86450a47899254e2faa82dca3c2cf2',
             ...     'split_account': 'Checking', 'action': '', 'payee': 'payee',
-            ...     'date': dt(2010, 6, 12, 0, 0), 'category': '',
+            ...     'date': datetime.datetime(2010, 6, 12, 0, 0), 'category': '',
             ...     'bank_id': 'e268443e43d93dab7ebef303bbe9642f',
             ...     'price': Decimal('0'), 'symbol': '', 'check_num': None,
             ...     'inv_split_account': None, 'x_action': '', 'type': 'DEBIT',
@@ -226,7 +227,7 @@ ENCODING:USASCIICHARSET:1252COMPRESSION:NONEOLDFILEUID:NONENEWFILEUID:NONE\
             (str): the OFX content
 
         Examples:
-            >>> kwargs = {'start': dt(2012, 1, 1), 'end': dt(2012, 2, 1)}
+            >>> kwargs = {'start': datetime.datetime(2012, 1, 1), 'end': datetime.datetime(2012, 2, 1)}
             >>> akwargs = {'currency': 'USD', 'bank_id': 1, 'account_id': 1, \
 'account_type': 'CHECKING'}
             >>> start = '<STMTRS><CURDEF>USD</CURDEF><BANKACCTFROM><BANKID>1\
@@ -286,7 +287,7 @@ ENCODING:USASCIICHARSET:1252COMPRESSION:NONEOLDFILEUID:NONENEWFILEUID:NONE\
             (str): the OFX content
 
         Examples:
-            >>> kwargs = {'date': dt(2012, 1, 15), 'type': 'DEBIT', \
+            >>> kwargs = {'date': datetime.datetime(2012, 1, 15), 'type': 'DEBIT', \
 'amount': 100, 'id': 1, 'check_num': 1, 'payee': 'payee', 'memo': 'memo'}
             >>> trxn = '<STMTTRN><TRNTYPE>DEBIT</TRNTYPE><DTPOSTED>\
 20120115000000</DTPOSTED><TRNAMT>100.00</TRNAMT><FITID>1</FITID><CHECKNUM>1\
@@ -329,7 +330,7 @@ ENCODING:USASCIICHARSET:1252COMPRESSION:NONEOLDFILEUID:NONENEWFILEUID:NONE\
             (str): the OFX content
 
         Examples:
-            >>> kwargs = {'balance': 150, 'date': dt(2012, 1, 15)}
+            >>> kwargs = {'balance': 150, 'date': datetime.datetime(2012, 1, 15)}
             >>> end = '</BANKTRANLIST><LEDGERBAL><BALAMT>150.00</BALAMT>\
 <DTASOF>20120115000000</DTASOF></LEDGERBAL></STMTRS>'
             >>> result = OFX().account_end(**kwargs)
@@ -408,7 +409,7 @@ ENCODING:USASCIICHARSET:1252COMPRESSION:NONEOLDFILEUID:NONENEWFILEUID:NONE\
             (str): the start of an OFX transfer
 
         Examples:
-            >>> kwargs = {'currency': 'USD', 'date': dt(2012, 1, 15), \
+            >>> kwargs = {'currency': 'USD', 'date': datetime.datetime(2012, 1, 15), \
 'bank_id': 1, 'account_id': 1, 'account_type': 'CHECKING', 'amount': 100, \
 'id': 'jbaevf'}
             >>> trxn = '<INTRARS><CURDEF>USD</CURDEF><SRVRTID>jbaevf</SRVRTID>\
@@ -508,7 +509,7 @@ ENCODING:USASCIICHARSET:1252COMPRESSION:NONEOLDFILEUID:NONENEWFILEUID:NONE\
 
         Examples:
             >>> end = '</XFERINFO><DTPOSTED>20120115000000</DTPOSTED></INTRARS>'
-            >>> result = OFX().transfer_end(dt(2012, 1, 15))
+            >>> result = OFX().transfer_end(datetime.datetime(2012, 1, 15))
             >>> end == result.replace('\\n', '').replace('\\t', '')
             True
         """
@@ -529,12 +530,12 @@ ENCODING:USASCIICHARSET:1252COMPRESSION:NONEOLDFILEUID:NONENEWFILEUID:NONE\
 
         Examples:
             >>> ft = '</BANKTRANLIST></STMTRS></STMTTRNRS></BANKMSGSRSV1></OFX>'
-            >>> result = OFX().footer(date=dt(2012, 1, 15))
+            >>> result = OFX().footer(date=datetime.datetime(2012, 1, 15))
             >>> result = list(result)[0]
             >>> ft == result.replace('\\n', '').replace('\\t', '')
             True
         """
-        kwargs.setdefault("date", dt.now())
+        kwargs.setdefault("date", datetime.datetime.now())
 
         if self.is_split:
             content = self.transfer_end(**kwargs)
@@ -617,21 +618,21 @@ ENCODING:USASCIICHARSET:1252COMPRESSION:NONEOLDFILEUID:NONENEWFILEUID:NONE\
 
         Examples:
             >>> ofx = OFX()
-            >>> trxn1 = { 'date': dt(2010, 6, 12, 0, 0) }
-            >>> trxn2 = { 'date': dt(2010, 6, 12, 0, 0) }
-            >>> trxn3 = { 'date': dt(2010, 6, 13, 0, 0) }
+            >>> trxn1 = { 'date': datetime.datetime(2010, 6, 12, 0, 0) }
+            >>> trxn2 = { 'date': datetime.datetime(2010, 6, 12, 0, 0) }
+            >>> trxn3 = { 'date': datetime.datetime(2010, 6, 13, 0, 0) }
             >>> ofx.update_latest_trxn(trxn1)
-            >>> ofx.latest_trxn['date'] == dt(2010, 6, 12, 0, 0)
+            >>> ofx.latest_trxn['date'] == datetime.datetime(2010, 6, 12, 0, 0)
             True
             >>> ofx.latest_date_count
             1
             >>> ofx.update_latest_trxn(trxn2)
-            >>> ofx.latest_trxn['date'] == dt(2010, 6, 12, 0, 0)
+            >>> ofx.latest_trxn['date'] == datetime.datetime(2010, 6, 12, 0, 0)
             True
             >>> ofx.latest_date_count
             2
             >>> ofx.update_latest_trxn(trxn3)
-            >>> ofx.latest_trxn['date'] == dt(2010, 6, 13, 0, 0)
+            >>> ofx.latest_trxn['date'] == datetime.datetime(2010, 6, 13, 0, 0)
             True
             >>> ofx.latest_date_count
             1
@@ -653,10 +654,10 @@ ENCODING:USASCIICHARSET:1252COMPRESSION:NONEOLDFILEUID:NONENEWFILEUID:NONE\
 
         Examples:
             >>> ofx = OFX()
-            >>> trxn1 = { 'date': dt(2010, 6, 12, 0, 0) }
-            >>> trxn2 = { 'date': dt(2010, 6, 12, 0, 0) }
-            >>> trxn3 = { 'date': dt(2010, 6, 13, 0, 0) }
-            >>> trxn4 = { 'date': dt(2010, 6, 11, 0, 0) }
+            >>> trxn1 = { 'date': datetime.datetime(2010, 6, 12, 0, 0) }
+            >>> trxn2 = { 'date': datetime.datetime(2010, 6, 12, 0, 0) }
+            >>> trxn3 = { 'date': datetime.datetime(2010, 6, 13, 0, 0) }
+            >>> trxn4 = { 'date': datetime.datetime(2010, 6, 11, 0, 0) }
             >>> ofx.update_last_trxn(trxn1)
             >>> ofx.check_date_order(trxn2)
             >>> ofx.dates_ascending

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ test = [
 	"pytest",
 	"pytest-enabler",
 	"pytest-ruff",
+	"freezegun",
 ]
 
 [tool.setuptools]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,12 +2,12 @@ import itertools
 import pathlib
 import shlex
 import subprocess
+import time
 
+import freezegun
 import pytest
 
 import csv2ofx.main
-
-SERVER_DATE = "-D 20161031112908"
 
 samples = [
     (["-oq"], "default.csv", "default.qif"),
@@ -17,29 +17,29 @@ samples = [
     (["-oq", "-m mint_extra"], "mint_extra.csv", "mint_extra.qif"),
     (["-oq", "-m mint_headerless"], "mint_headerless.csv", "mint.qif"),
     (["-oqs20150613", "-e20150614", "-m mint"], "mint.csv", "mint_alt.qif"),
-    (["-oe 20150908", SERVER_DATE], "default.csv", "default.ofx"),
-    (["-o", "-m split_account", SERVER_DATE], "default.csv", "default_w_splits.ofx"),
-    (["-o", "-m mint", SERVER_DATE], "mint.csv", "mint.ofx"),
+    (["-oe 20150908"], "default.csv", "default.ofx"),
+    (["-o", "-m split_account"], "default.csv", "default_w_splits.ofx"),
+    (["-o", "-m mint"], "mint.csv", "mint.ofx"),
     (["-oq", "-m creditunion"], "creditunion.csv", "creditunion.qif"),
     (
-        ["-o", "-m stripe", "-e", "20210505", SERVER_DATE],
+        ["-o", "-m stripe", "-e", "20210505"],
         "stripe-default.csv",
         "stripe-default.ofx",
     ),
     (
-        ["-o", "-m stripe", "-e", "20210505", SERVER_DATE],
+        ["-o", "-m stripe", "-e", "20210505"],
         "stripe-all.csv",
         "stripe-all.ofx",
     ),
     (["-oq", "-m stripe"], "stripe-default.csv", "stripe-default.qif"),
     (["-oq", "-m stripe"], "stripe-all.csv", "stripe-all.qif"),
     (
-        ["-E windows-1252", "-m gls", SERVER_DATE, "-e 20171111", "-o"],
+        ["-E windows-1252", "-m gls", "-e 20171111", "-o"],
         "gls.csv",
         "gls.ofx",
     ),
     (
-        ["-o", "-m pcmastercard", "-e 20190120", SERVER_DATE],
+        ["-o", "-m pcmastercard", "-e 20190120"],
         "pcmastercard.csv",
         "pcmastercard.ofx",
     ),
@@ -49,67 +49,67 @@ samples = [
     #     ["-oq", "-m ubs-ch-fr"], "ubs-ch-fr_trimmed.csv", "ubs-ch-fr.qif"
     # ),
     (
-        ["-o", "-m ingesp", "-e 20221231", SERVER_DATE],
+        ["-o", "-m ingesp", "-e 20221231"],
         "ingesp.csv",
         "ingesp.ofx",
     ),
     (
-        ["-o", "-m schwabchecking", "-e 20220905", SERVER_DATE],
+        ["-o", "-m schwabchecking", "-e 20220905"],
         "schwab-checking.csv",
         "schwab-checking.ofx",
     ),
     (
-        ["-o", "-M", "-m schwabchecking", "-e 20220905", SERVER_DATE],
+        ["-o", "-M", "-m schwabchecking", "-e 20220905"],
         "schwab-checking.csv",
         "schwab-checking-msmoney.ofx",
     ),
     (
-        ["-o", "-m schwabchecking", "-e 20220905", SERVER_DATE],
+        ["-o", "-m schwabchecking", "-e 20220905"],
         "schwab-checking-baltest-case1.csv",
         "schwab-checking-baltest-case1.ofx",
     ),
     (
-        ["-o", "-m schwabchecking", "-e 20220905", SERVER_DATE],
+        ["-o", "-m schwabchecking", "-e 20220905"],
         "schwab-checking-baltest-case2.csv",
         "schwab-checking-baltest-case2.ofx",
     ),
     (
-        ["-o", "-m schwabchecking", "-e 20220905", SERVER_DATE],
+        ["-o", "-m schwabchecking", "-e 20220905"],
         "schwab-checking-baltest-case3.csv",
         "schwab-checking-baltest-case3.ofx",
     ),
     (
-        ["-o", "-m schwabchecking", "-e 20220905", SERVER_DATE],
+        ["-o", "-m schwabchecking", "-e 20220905"],
         "schwab-checking-baltest-case4.csv",
         "schwab-checking-baltest-case4.ofx",
     ),
     (
-        ["-o", "-m schwabchecking", "-e 20220905", SERVER_DATE],
+        ["-o", "-m schwabchecking", "-e 20220905"],
         "schwab-checking-baltest-case5.csv",
         "schwab-checking-baltest-case5.ofx",
     ),
     (
-        ["-o", "-m schwabchecking", "-e 20220905", SERVER_DATE],
+        ["-o", "-m schwabchecking", "-e 20220905"],
         "schwab-checking-baltest-case6.csv",
         "schwab-checking-baltest-case6.ofx",
     ),
     (
-        ["-o", "-m schwabchecking", "-e 20220905", SERVER_DATE],
+        ["-o", "-m schwabchecking", "-e 20220905"],
         "schwab-checking-baltest-case7.csv",
         "schwab-checking-baltest-case7.ofx",
     ),
     (
-        ["-o", "-m amazon", "-e 20230604", SERVER_DATE],
+        ["-o", "-m amazon", "-e 20230604"],
         "amazon.csv",
         "amazon.ofx",
     ),
     (
-        ["-o", "-m payoneer", "-e 20220905", SERVER_DATE],
+        ["-o", "-m payoneer", "-e 20220905"],
         "payoneer.csv",
         "payoneer.ofx",
     ),
     (
-        ['-m', 'n26', SERVER_DATE],
+        ['-m', 'n26'],
         'n26-fr.csv',
         'n26.ofx',
     ),
@@ -132,7 +132,9 @@ def flatten_opts(opts):
 
 
 @pytest.mark.parametrize(['opts', 'in_filename', 'out_filename'], samples)
-def test_sample(opts, in_filename, out_filename, capsys):
+@freezegun.freeze_time("2016-10-31 11:29:08")
+def test_sample(opts, in_filename, out_filename, capsys, monkeypatch):
+    monkeypatch.setattr(csv2ofx.main, '_time_from_file', lambda path: time.time())
     arguments = [str(data / 'test' / in_filename)]
     command = list(itertools.chain(['csv2ofx'], flatten_opts(opts), arguments))
     with pytest.raises(SystemExit) as exc:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,8 @@ import subprocess
 
 import pytest
 
+import csv2ofx.main
+
 SERVER_DATE = "-D 20161031112908"
 
 samples = [
@@ -130,16 +132,16 @@ def flatten_opts(opts):
 
 
 @pytest.mark.parametrize(['opts', 'in_filename', 'out_filename'], samples)
-def test_sample(opts, in_filename, out_filename):
+def test_sample(opts, in_filename, out_filename, capsys):
     arguments = [str(data / 'test' / in_filename)]
     command = list(itertools.chain(['csv2ofx'], flatten_opts(opts), arguments))
-    proc = subprocess.run(
-        command, capture_output=True, text=True, encoding='utf-8', check=True
-    )
-    output = proc.stdout
+    with pytest.raises(SystemExit) as exc:
+        csv2ofx.main.run(command[1:])
+    # Success - exit code 0
+    assert exc.value.code == 0
 
     expected = data.joinpath("converted", out_filename).read_text(encoding='utf-8')
-    assert output == expected, (
+    assert capsys.readouterr().out == expected, (
         f"Unexpected output from {subprocess.list2cmdline(command)}"
     )
 


### PR DESCRIPTION
Refactored the tests to run the samples in-process instead of launching a subprocess, giving the ability to capture stdout and monkey patch other behaviors (file modified time detection).

This refactoring revealed some bugs about how the stream handling was done.

This approach gives us more control when testing the mappings.

Note that the CLI executable is still exercised in `test_help*`.

- **Simply import the module.**
- **Allow args to be passed in explicitly (to facilitate testing).**
- **Use sys namespace.**
- **In test_sample, exercise the code in process.**
- **Fix resource warnings about unclosed source.**
- **Freeze time and bypass file mtime check for to avoid passing a fixed date with each command.**
